### PR TITLE
Redoing 'Fixed bot displaying wrong game version'

### DIFF
--- a/LinkMeBot.py
+++ b/LinkMeBot.py
@@ -53,7 +53,7 @@ def search(keyword, count):
                     response_list.append("[**" + result["title"] + "**](" +
                                         "https://mods.factorio.com/mods/" + result["owner"] + "/" + result["name"] + ") - By: " +
                                         result["owner"] + " - Game Version: " +
-                                        result["latest_release"]["game_version"])
+                                        result["latest_release"]["factorio_version"])
         #If enough results were found
         if(len(response_list) >= count):
             #Return response list truncated to count
@@ -66,7 +66,7 @@ def search(keyword, count):
                     response_list.append("[**" + result["title"] + "**](" +
                                         "https://mods.factorio.com/mods/" + result["owner"] + "/" + result["name"] + ") - By: " +
                                         result["owner"] + " - Game Version: " +
-                                        result["latest_release"]["game_version"])
+                                        result["latest_release"]["factorio_version"])
     return response_list[:count]
 
 #Checks if an author of a mod exists    


### PR DESCRIPTION
This PR redoes the bug fix in https://github.com/michael-3-141/FactorioModPortalBot/commit/f91d0fcf3e73d8cd15fc5ecc53870801eb8d704c that was lost during a recent conflict merge.

Conflict merge commit: https://github.com/michael-3-141/FactorioModPortalBot/commit/7a34f5a6c5bf85b6ea67143470f1e86d6e6e651b that brought in commit that overwrote bugfix: https://github.com/michael-3-141/FactorioModPortalBot/commit/06ff06274d86d2ff1d0492092f06fc19f4574a0e
